### PR TITLE
Make elasticsearch clusterName configurable

### DIFF
--- a/zeebe-operate/templates/configmap.yaml
+++ b/zeebe-operate/templates/configmap.yaml
@@ -9,7 +9,7 @@ data:
       # ELS instance to store Operate data
       elasticsearch:
         # Cluster name
-        clusterName: elasticsearch
+        clusterName: {{ .Values.global.elasticsearch.clusterName }}
         # Host
         host: {{ .Values.global.elasticsearch.host }}
         # Transport port
@@ -21,7 +21,7 @@ data:
       # ELS instance to export Zeebe data to
       zeebeElasticsearch:
         # Cluster name
-        clusterName: elasticsearch
+        clusterName: {{ .Values.global.elasticsearch.clusterName }}
         # Host
         host: {{ .Values.global.elasticsearch.host }}
         # Transport port

--- a/zeebe-operate/values.yaml
+++ b/zeebe-operate/values.yaml
@@ -3,6 +3,7 @@ global:
   elasticsearch:
     host: "elasticsearch-master"
     port: 9200
+    clusterName: "elasticsearch"
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
Since we install several elasticsearch instances for different purposes in our Kubernetes namespace we need to be able to customize the elasticsearch cluster name. We can currently do this in the zeebe-cluster helm chart, but not in this one