### PR TITLE
Fix incorrect brokerContactPoint when charts are used separately

### DIFF
--- a/zeebe-operate/values.yaml
+++ b/zeebe-operate/values.yaml
@@ -1,5 +1,5 @@
 global:
-  zeebe: "{{ .Release.Name }}-zeebe-gateway" #the zeebe service instance where operate will connect
+  zeebe: "{{ .Release.Name }}-zeebe"
   elasticsearch:
     host: "elasticsearch-master"
     port: 9200


### PR DESCRIPTION
When zeebe-cluster and zeebe-operate are called separately (instead of using zeebe-full), this helm chart sets operate's brokerContactPoint to a service name with an extra -gateway prefix.

This is not an issue when using zeebe-full, since it explicitly sets global.zeebe, overwriting the default in this chart.

This change matches the default `global.zeebe` to what [is set in zeebe-cluster](https://github.com/zeebe-io/zeebe-cluster-helm/blob/master/zeebe-cluster/values.yaml#L9), so the `brokerContactPoint` is set to the correct service name.

**Related Issues**

Fixes https://github.com/zeebe-io/zeebe-operate-helm/issues/7