### PR TITLE
Add index prefix as configuration option

### DIFF
--- a/charts/zeebe-operate-helm/templates/configmap.yaml
+++ b/charts/zeebe-operate-helm/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
         # Transport port
         port: {{ .Values.global.elasticsearch.port }}
         # Index prefix, configured in Zeebe Elasticsearch exporter
-        prefix: zeebe-record
+        prefix: {{ .Values.global.elasticsearch.prefix }}
     logging:
 {{- with .Values.logging }}
 {{ . | toYaml | indent 6 }}

--- a/charts/zeebe-operate-helm/values.yaml
+++ b/charts/zeebe-operate-helm/values.yaml
@@ -4,6 +4,7 @@ global:
     host: "elasticsearch-master"
     port: 9200
     clusterName: "elasticsearch"
+    prefix: zeebe-record
 
 logging:
   level:


### PR DESCRIPTION
Hi,

Zeebe exporter for Elasticsearch can be configured to use a specific index prefix (defaulting to zeebe-record), but it is not currently possible to set the same index prefix in this chart.

This PR adds this option.