### PR TITLE
Add TLS support in ingress resource

### DIFF
--- a/charts/zeebe-operate-helm/templates/ingress.yaml
+++ b/charts/zeebe-operate-helm/templates/ingress.yaml
@@ -20,4 +20,12 @@ spec:
             backend:
               serviceName: {{ include "zeebe-operate.fullname" . }}
               servicePort: 80
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/zeebe-operate-helm/values.yaml
+++ b/charts/zeebe-operate-helm/values.yaml
@@ -33,3 +33,6 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"    
   path: /
   host:
+  tls:
+    enabled: false
+    secretName:


### PR DESCRIPTION
Hi,

This one is pretty self-explanatory, it adds support for TLS in the ingress resource.

TLS is disabled by default, and secretName is optional because it's not always required.